### PR TITLE
Add internal dependencies

### DIFF
--- a/{{cookiecutter.package_slug}}/pyproject.toml
+++ b/{{cookiecutter.package_slug}}/pyproject.toml
@@ -24,6 +24,10 @@ dev = [
     "pylint"
     ]
 
+internal = [
+
+    ]
+
 [build-system]
 requires = ["setuptools>=60.0.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
My suggestion for managing internal dependencies without our wheel repo. Fixes #3 
Gives the user 2 options:

1. Want to have specific dependencies in given version? - use the pyproject section as reference and install them by hand.
2. Want to just install the package? call `package-name[internal]` It will be downloaded from the main branch.

Usage example:
```
[project.optional-dependencies]
dev = [
    "pytest",
    "isort",
    "black",
    "pylint"
    ]

internal = [
    "lightning-diffusion @ git+https://github.com/network-science-lab/lightning-diffusion"
    ]
```
```bash
pip install package-name[internal]
